### PR TITLE
[BUG-72] fix: notifications sent twice on Slack (#76)

### DIFF
--- a/src/Listeners/ExceptionLogGroupCreatedListener.php
+++ b/src/Listeners/ExceptionLogGroupCreatedListener.php
@@ -4,6 +4,7 @@ namespace Taecontrol\MoonGuard\Listeners;
 
 use Illuminate\Support\Facades\Notification;
 use Taecontrol\MoonGuard\Repositories\UserRepository;
+use Taecontrol\MoonGuard\Notifications\SlackNotifiable;
 use Taecontrol\MoonGuard\Events\ExceptionLogGroupCreatedEvent;
 use Taecontrol\MoonGuard\Notifications\ExceptionLogGroupNotification;
 
@@ -11,9 +12,15 @@ class ExceptionLogGroupCreatedListener
 {
     public function handle(ExceptionLogGroupCreatedEvent $event): void
     {
-        Notification::send(
-            UserRepository::all(),
-            new ExceptionLogGroupNotification($event->exceptionLogGroup)
-        );
+        $channels = config('moonguard.notifications.channels');
+
+        foreach ($channels as $channel) {
+            $notifiables = ($channel === 'slack') ? new SlackNotifiable() : UserRepository::all();
+
+            Notification::send(
+                $notifiables,
+                new ExceptionLogGroupNotification($event->exceptionLogGroup, $channel)
+            );
+        }
     }
 }

--- a/src/Listeners/ExceptionLogGroupUpdatedListener.php
+++ b/src/Listeners/ExceptionLogGroupUpdatedListener.php
@@ -4,6 +4,7 @@ namespace Taecontrol\MoonGuard\Listeners;
 
 use Illuminate\Support\Facades\Notification;
 use Taecontrol\MoonGuard\Repositories\UserRepository;
+use Taecontrol\MoonGuard\Notifications\SlackNotifiable;
 use Taecontrol\MoonGuard\Events\ExceptionLogGroupUpdatedEvent;
 use Taecontrol\MoonGuard\Notifications\ExceptionLogGroupNotification;
 
@@ -11,9 +12,15 @@ class ExceptionLogGroupUpdatedListener
 {
     public function handle(ExceptionLogGroupUpdatedEvent $event): void
     {
-        Notification::send(
-            UserRepository::all(),
-            new ExceptionLogGroupNotification($event->exceptionLogGroup)
-        );
+        $channels = config('moonguard.notifications.channels');
+
+        foreach ($channels as $channel) {
+            $notifiables = ($channel === 'slack') ? new SlackNotifiable() : UserRepository::all();
+
+            Notification::send(
+                $notifiables,
+                new ExceptionLogGroupNotification($event->exceptionLogGroup, $channel)
+            );
+        }
     }
 }

--- a/src/Listeners/RequestTookLongerThanMaxDurationListener.php
+++ b/src/Listeners/RequestTookLongerThanMaxDurationListener.php
@@ -4,6 +4,7 @@ namespace Taecontrol\MoonGuard\Listeners;
 
 use Illuminate\Support\Facades\Notification;
 use Taecontrol\MoonGuard\Repositories\UserRepository;
+use Taecontrol\MoonGuard\Notifications\SlackNotifiable;
 use Taecontrol\MoonGuard\Events\RequestTookLongerThanMaxDurationEvent;
 use Taecontrol\MoonGuard\Notifications\RequestTookLongerThanMaxDurationNotification;
 
@@ -11,9 +12,19 @@ class RequestTookLongerThanMaxDurationListener
 {
     public function handle(RequestTookLongerThanMaxDurationEvent $event): void
     {
-        Notification::send(
-            UserRepository::all(),
-            new RequestTookLongerThanMaxDurationNotification($event->uptimeCheck, $event->maxRequestDuration)
-        );
+        $channels = config('moonguard.notifications.channels');
+
+        foreach ($channels as $channel) {
+            $notifiables = ($channel === 'slack') ? new SlackNotifiable() : UserRepository::all();
+
+            Notification::send(
+                $notifiables,
+                new RequestTookLongerThanMaxDurationNotification(
+                    $event->uptimeCheck,
+                    $event->maxRequestDuration,
+                    $channel
+                )
+            );
+        }
     }
 }

--- a/src/Listeners/SslCertificateCheckFailedListener.php
+++ b/src/Listeners/SslCertificateCheckFailedListener.php
@@ -4,6 +4,7 @@ namespace Taecontrol\MoonGuard\Listeners;
 
 use Illuminate\Support\Facades\Notification;
 use Taecontrol\MoonGuard\Repositories\UserRepository;
+use Taecontrol\MoonGuard\Notifications\SlackNotifiable;
 use Taecontrol\MoonGuard\Events\SslCertificateCheckFailedEvent;
 use Taecontrol\MoonGuard\Notifications\SslCertificateCheckFailedNotification;
 
@@ -11,9 +12,15 @@ class SslCertificateCheckFailedListener
 {
     public function handle(SslCertificateCheckFailedEvent $event): void
     {
-        Notification::send(
-            UserRepository::all(),
-            new SslCertificateCheckFailedNotification($event->sslCertificateCheck)
-        );
+        $channels = config('moonguard.notifications.channels');
+
+        foreach ($channels as $channel) {
+            $notifiables = ($channel === 'slack') ? new SlackNotifiable() : UserRepository::all();
+
+            Notification::send(
+                $notifiables,
+                new SslCertificateCheckFailedNotification($event->sslCertificateCheck, $channel)
+            );
+        }
     }
 }

--- a/src/Listeners/SslCertificateExpiresSoonListener.php
+++ b/src/Listeners/SslCertificateExpiresSoonListener.php
@@ -4,6 +4,7 @@ namespace Taecontrol\MoonGuard\Listeners;
 
 use Illuminate\Support\Facades\Notification;
 use Taecontrol\MoonGuard\Repositories\UserRepository;
+use Taecontrol\MoonGuard\Notifications\SlackNotifiable;
 use Taecontrol\MoonGuard\Events\SslCertificateExpiresSoonEvent;
 use Taecontrol\MoonGuard\Notifications\SslCertificateExpiresSoonNotification;
 
@@ -11,9 +12,15 @@ class SslCertificateExpiresSoonListener
 {
     public function handle(SslCertificateExpiresSoonEvent $event): void
     {
-        Notification::send(
-            UserRepository::all(),
-            new SslCertificateExpiresSoonNotification($event->sslCertificateCheck)
-        );
+        $channels = config('moonguard.notifications.channels');
+
+        foreach ($channels as $channel) {
+            $notifiables = ($channel === 'slack') ? new SlackNotifiable() : UserRepository::all();
+
+            Notification::send(
+                $notifiables,
+                new SslCertificateExpiresSoonNotification($event->sslCertificateCheck, $channel)
+            );
+        }
     }
 }

--- a/src/Listeners/UptimeCheckFailedListener.php
+++ b/src/Listeners/UptimeCheckFailedListener.php
@@ -5,15 +5,26 @@ namespace Taecontrol\MoonGuard\Listeners;
 use Illuminate\Support\Facades\Notification;
 use Taecontrol\MoonGuard\Repositories\UserRepository;
 use Taecontrol\MoonGuard\Events\UptimeCheckFailedEvent;
+use Taecontrol\MoonGuard\Notifications\SlackNotifiable;
 use Taecontrol\MoonGuard\Notifications\UptimeCheckFailedNotification;
 
 class UptimeCheckFailedListener
 {
     public function handle(UptimeCheckFailedEvent $event): void
     {
-        Notification::send(
-            UserRepository::all(),
-            new UptimeCheckFailedNotification($event->uptimeCheck, $event->downtimePeriod)
-        );
+        $channels = config('moonguard.notifications.channels');
+
+        foreach ($channels as $channel) {
+            $notifiables = ($channel === 'slack') ? new SlackNotifiable() : UserRepository::all();
+
+            Notification::send(
+                $notifiables,
+                new UptimeCheckFailedNotification(
+                    $event->uptimeCheck,
+                    $event->downtimePeriod,
+                    $channel
+                )
+            );
+        }
     }
 }

--- a/src/Listeners/UptimeCheckRecoveredListener.php
+++ b/src/Listeners/UptimeCheckRecoveredListener.php
@@ -4,6 +4,7 @@ namespace Taecontrol\MoonGuard\Listeners;
 
 use Illuminate\Support\Facades\Notification;
 use Taecontrol\MoonGuard\Repositories\UserRepository;
+use Taecontrol\MoonGuard\Notifications\SlackNotifiable;
 use Taecontrol\MoonGuard\Events\UptimeCheckRecoveredEvent;
 use Taecontrol\MoonGuard\Notifications\UptimeCheckRecoveredNotification;
 
@@ -11,9 +12,19 @@ class UptimeCheckRecoveredListener
 {
     public function handle(UptimeCheckRecoveredEvent $event): void
     {
-        Notification::send(
-            UserRepository::all(),
-            new UptimeCheckRecoveredNotification($event->uptimeCheck, $event->downtimePeriod)
-        );
+        $channels = config('moonguard.notifications.channels');
+
+        foreach ($channels as $channel) {
+            $notifiables = ($channel === 'slack') ? new SlackNotifiable() : UserRepository::all();
+
+            Notification::send(
+                $notifiables,
+                new UptimeCheckRecoveredNotification(
+                    $event->uptimeCheck,
+                    $event->downtimePeriod,
+                    $channel
+                )
+            );
+        }
     }
 }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -38,11 +38,6 @@ class User extends Model implements MoonGuardUser
         'email_verified_at' => 'datetime',
     ];
 
-    public function routeNotificationForSlack(): string
-    {
-        return config('moonguard.notifications.slack.webhook_url');
-    }
-
     protected static function newFactory(): Factory
     {
         return UserFactory::new();

--- a/src/Notifications/ExceptionLogGroupNotification.php
+++ b/src/Notifications/ExceptionLogGroupNotification.php
@@ -14,13 +14,15 @@ class ExceptionLogGroupNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    public function __construct(public MoonGuardExceptionLogGroup $exceptionLogGroup)
-    {
+    public function __construct(
+        public MoonGuardExceptionLogGroup $exceptionLogGroup,
+        public String $channel
+    ) {
     }
 
-    public function via(): array
+    public function via(): string
     {
-        return config('moonguard.notifications.channels');
+        return $this->channel;
     }
 
     public function toMail(): MailMessage

--- a/src/Notifications/RequestTookLongerThanMaxDurationNotification.php
+++ b/src/Notifications/RequestTookLongerThanMaxDurationNotification.php
@@ -15,13 +15,16 @@ class RequestTookLongerThanMaxDurationNotification extends Notification implemen
 {
     use Queueable;
 
-    public function __construct(public MoonGuardUptimeCheck $uptimeCheck, public RequestDuration $maxRequestDuration)
-    {
+    public function __construct(
+        public MoonGuardUptimeCheck $uptimeCheck,
+        public RequestDuration $maxRequestDuration,
+        public String $channel
+    ) {
     }
 
-    public function via(): array
+    public function via(): string
     {
-        return config('moonguard.notifications.channels');
+        return $this->channel;
     }
 
     public function toMail(): MailMessage

--- a/src/Notifications/SlackNotifiable.php
+++ b/src/Notifications/SlackNotifiable.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Taecontrol\MoonGuard\Notifications;
+
+use Illuminate\Notifications\Notifiable;
+
+class SlackNotifiable
+{
+    use Notifiable;
+
+    public function routeNotificationForSlack(): string
+    {
+        return config('moonguard.notifications.slack.webhook_url');
+    }
+}

--- a/src/Notifications/SslCertificateCheckFailedNotification.php
+++ b/src/Notifications/SslCertificateCheckFailedNotification.php
@@ -14,13 +14,15 @@ class SslCertificateCheckFailedNotification extends Notification implements Shou
 {
     use Queueable;
 
-    public function __construct(public MoonGuardSslCertificateCheck $sslCertificateCheck)
-    {
+    public function __construct(
+        public MoonGuardSslCertificateCheck $sslCertificateCheck,
+        public String $channel
+    ) {
     }
 
-    public function via(): array
+    public function via(): string
     {
-        return config('moonguard.notifications.channels');
+        return $this->channel;
     }
 
     public function toMail(): MailMessage

--- a/src/Notifications/SslCertificateExpiresSoonNotification.php
+++ b/src/Notifications/SslCertificateExpiresSoonNotification.php
@@ -14,13 +14,15 @@ class SslCertificateExpiresSoonNotification extends Notification implements Shou
 {
     use Queueable;
 
-    public function __construct(public MoonGuardSslCertificateCheck $sslCertificateCheck)
-    {
+    public function __construct(
+        public MoonGuardSslCertificateCheck $sslCertificateCheck,
+        public String $channel
+    ) {
     }
 
-    public function via(): array
+    public function via(): string
     {
-        return config('moonguard.notifications.channels');
+        return $this->channel;
     }
 
     public function toMail(): MailMessage

--- a/src/Notifications/UptimeCheckFailedNotification.php
+++ b/src/Notifications/UptimeCheckFailedNotification.php
@@ -15,13 +15,16 @@ class UptimeCheckFailedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    public function __construct(public MoonGuardUptimeCheck $uptime, Period $downtimePeriod)
-    {
+    public function __construct(
+        public MoonGuardUptimeCheck $uptime,
+        Period $downtimePeriod,
+        public String $channel
+    ) {
     }
 
-    public function via(): array
+    public function via(): string
     {
-        return config('moonguard.notifications.channels');
+        return $this->channel;
     }
 
     public function toMail(): MailMessage

--- a/src/Notifications/UptimeCheckRecoveredNotification.php
+++ b/src/Notifications/UptimeCheckRecoveredNotification.php
@@ -15,13 +15,16 @@ class UptimeCheckRecoveredNotification extends Notification implements ShouldQue
 {
     use Queueable;
 
-    public function __construct(public MoonGuardUptimeCheck $uptime, public Period $downtimePeriod)
-    {
+    public function __construct(
+        public MoonGuardUptimeCheck $uptime,
+        public Period $downtimePeriod,
+        public String $channel
+    ) {
     }
 
-    public function via(): array
+    public function via(): string
     {
-        return config('moonguard.notifications.channels');
+        return $this->channel;
     }
 
     public function toMail(): MailMessage


### PR DESCRIPTION
* [#72] add SlackNotiable class

* [#72] update ssl certificate check failed notifications

* [#72] update exception notifications

* [#72] update request took longer max duration notifications

* [#72] update ssl certificate notifications

* [#72] update uptime check notifications

* [#72] more fixes

* [#72] fixer

* Update src/Listeners/ExceptionLogGroupCreatedListener.php



* Update src/Listeners/ExceptionLogGroupUpdatedListener.php



* Update src/Listeners/RequestTookLongerThanMaxDurationListener.php



* Update src/Listeners/SslCertificateCheckFailedListener.php



* Update src/Listeners/SslCertificateExpiresSoonListener.php



* Update src/Listeners/UptimeCheckRecoveredListener.php



* Update src/Listeners/UptimeCheckFailedListener.php



* [#72] more listener fixes

* [#72]  remove routeNotificationForSlack() method

---------